### PR TITLE
Increase gas so we don't run out

### DIFF
--- a/truffle.js
+++ b/truffle.js
@@ -2,7 +2,7 @@ module.exports = {
   rpc: {
     host: 'localhost',
     port: 8545,
-    gas: 190000
+    gas: 2000000
   },
   migrations_directory: './migrations'
 }


### PR DESCRIPTION
I got the following error and increasing the gas to 2,000,000 fixed it:
```
$ npm run start

> truffle-webpack@0.0.1 start /home/wink/foss/ethereum/truffle-webpack-demo.my-fork
> node ./scripts/start.js

Starting the development server...

[TRUFFLE SOLIDITY] Writing temporary contract build artifacts to /home/wink/foss/ethereum/truffle-webpack-demo.my-fork/.truffle-solidity-loader
[TRUFFLE SOLIDITY] Compiling ConvertLib.sol...
[TRUFFLE SOLIDITY] Compiling MetaCoin.sol...
[TRUFFLE SOLIDITY] Writing artifacts to ./.truffle-solidity-loader
[TRUFFLE SOLIDITY] COMPILATION FINISHED
[TRUFFLE SOLIDITY] RUNNING MIGRATIONS
[TRUFFLE SOLIDITY] Running migration: 1_initial_migration.js
[TRUFFLE SOLIDITY]   Deploying Migrations...
[TRUFFLE SOLIDITY]   Migrations: 0xe78a0f7e598cc8b0bb87894b0f60dd2a88d6a8ab
[TRUFFLE SOLIDITY] Saving successful migration to network...
[TRUFFLE SOLIDITY] Saving artifacts...
[TRUFFLE SOLIDITY] Running migration: 2_deploy_contracts.js
[TRUFFLE SOLIDITY]   Deploying ConvertLib...
[TRUFFLE SOLIDITY]   ConvertLib: 0xcfeb869f69431e42cdb54a4f4f105c19c080a601
[TRUFFLE SOLIDITY]   Linking ConvertLib to MetaCoin
[TRUFFLE SOLIDITY]   Deploying MetaCoin...
[TRUFFLE SOLIDITY] Error encountered, bailing. Network state unknown. Review successful transactions manually.
[! TRUFFLE SOLIDITY ERROR] Error: VM Exception while processing transaction: out of gas
Failed to compile.

Error in ./contracts/MetaCoin.sol
Module build failed: Error: VM Exception while processing transaction: out of gas
 @ ./src/components/AccountList/AccountListContainer.js 33:16-49
```