### PR TITLE
Resolves issue 18: Now works with truffle 3 and updated truffle-solidity-loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 *.log
 /build
 .truffle-solidity-loader
+/dist

--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -3,7 +3,6 @@ var autoprefixer      = require('autoprefixer')
 var webpack           = require('webpack')
 var HtmlWebpackPlugin = require('html-webpack-plugin')
 var precss            = require('precss')
-var autoprefixer      = require('autoprefixer')
 
 // TODO: hide this behind a flag and eliminate dead code on eject.
 // This shouldn't be exposed to the user.
@@ -45,7 +44,9 @@ module.exports = {
     root: srcPath,
     extensions: ['', '.js'],
     alias: {
-      contracts: path.resolve('contracts')
+      contracts: path.resolve('contracts'),
+      // config: require('../truffle').networks.development
+      config: path.resolve('truffle.js')
     }
   },
   module: {
@@ -82,7 +83,7 @@ module.exports = {
       },
       {
         test: /\.sol/,
-        loader: 'truffle-solidity'
+        loaders: ['json-loader', 'truffle-solidity-loader?migrations_directory=' + path.resolve(__dirname, '../migrations') + '&network=development&contracts_build_directory=' + path.resolve(__dirname, '../dist/contracts') ]
       }
     ]
   },
@@ -101,8 +102,10 @@ module.exports = {
     }),
     new webpack.ProvidePlugin(provided),
     new webpack.DefinePlugin({
+      'myEnv': JSON.stringify(require('../truffle').networks.development),
       'process.env.NODE_ENV': '"development"'
     }),
+    new webpack.EnvironmentPlugin(['NODE_ENV']),
     new webpack.HotModuleReplacementPlugin()
   ]
 }

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -111,6 +111,7 @@ module.exports = {
       }
     }),
     new webpack.DefinePlugin({
+      'myEnv': JSON.stringify(require('../truffle').networks.production),
       'process.env.NODE_ENV': '"production"',
       WEB3_RPC_LOCATION: '"' + process.env.WEB3_RPC_LOCATION + '"'
     }),

--- a/contracts/ConvertLib.sol
+++ b/contracts/ConvertLib.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.4.4;
+
 library ConvertLib{
 	function convert(uint amount,uint conversionRate) returns (uint convertedAmount)
 	{

--- a/contracts/MetaCoin.sol
+++ b/contracts/MetaCoin.sol
@@ -13,7 +13,7 @@ contract MetaCoin {
 	event Transfer(address indexed _from, address indexed _to, uint256 _value);
 
 	function MetaCoin() {
-		balances[tx.origin] = 345;
+		balances[tx.origin] = 10000;
 	}
 
 	function sendCoin(address receiver, uint amount) returns(bool sufficient) {

--- a/contracts/MetaCoin.sol
+++ b/contracts/MetaCoin.sol
@@ -1,5 +1,6 @@
-pragma solidity ^0.4.0;
-import "ConvertLib.sol";
+pragma solidity ^0.4.4;
+
+import "./ConvertLib.sol";
 
 // This is just a simple example of a coin-like contract.
 // It is not standards compatible and cannot be expected to talk to other
@@ -9,14 +10,17 @@ import "ConvertLib.sol";
 contract MetaCoin {
 	mapping (address => uint) balances;
 
+	event Transfer(address indexed _from, address indexed _to, uint256 _value);
+
 	function MetaCoin() {
-		balances[tx.origin] = 10000;
+		balances[tx.origin] = 345;
 	}
 
 	function sendCoin(address receiver, uint amount) returns(bool sufficient) {
 		if (balances[msg.sender] < amount) return false;
 		balances[msg.sender] -= amount;
 		balances[receiver] += amount;
+		Transfer(msg.sender, receiver, amount);
 		return true;
 	}
 
@@ -25,6 +29,6 @@ contract MetaCoin {
 	}
 
 	function getBalance(address addr) returns(uint) {
-  	return balances[addr];
+		return balances[addr];
 	}
 }

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.4.4;
+
 contract Migrations {
   address public owner;
   uint public last_completed_migration;

--- a/migrations/1_initial_migration.js
+++ b/migrations/1_initial_migration.js
@@ -1,3 +1,5 @@
+var Migrations = artifacts.require("./Migrations.sol");
+
 module.exports = function(deployer) {
   deployer.deploy(Migrations);
 };

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -1,5 +1,8 @@
+var ConvertLib = artifacts.require("./ConvertLib.sol");
+var MetaCoin = artifacts.require("./MetaCoin.sol");
+
 module.exports = function(deployer) {
   deployer.deploy(ConvertLib);
-  deployer.autolink();
+  deployer.link(ConvertLib, MetaCoin);
   deployer.deploy(MetaCoin);
 };

--- a/package.json
+++ b/package.json
@@ -36,13 +36,13 @@
     "rimraf": "2.5.3",
     "style-loader": "0.13.1",
     "temp": "^0.8.3",
-    "truffle-solidity-loader": "0.0.8",
+    "truffle-contract": "^1.1.10",
+    "truffle-solidity-loader": "git+https://github.com/sogoiii/truffle-solidity-loader.git#1f1e213d52f033b6863218307b8968ae68220fe1",
     "url-loader": "0.5.7",
     "web3": "^0.17.0-alpha",
     "webpack": "1.13.1",
     "webpack-dev-server": "1.14.1"
   },
-  "dependencies": {},
   "scripts": {
     "start": "node ./scripts/start.js",
     "build": "node ./scripts/build.js"

--- a/src/components/AccountList/AccountListContainer.js
+++ b/src/components/AccountList/AccountListContainer.js
@@ -2,7 +2,10 @@ import React, { Component } from 'react'
 import AccountList from 'components/AccountList/AccountList'
 import SendCoin from 'components/SendCoin/SendCoin'
 
-import MetaCoin from 'contracts/MetaCoin.sol';
+import Contract from 'truffle-contract'
+import MetaCoinArtifact from 'contracts/MetaCoin.sol';
+const MetaCoin = Contract(MetaCoinArtifact)
+
 import Web3 from 'web3';
 
 const provider = new Web3.providers.HttpProvider('http://localhost:8545')
@@ -22,15 +25,17 @@ class AccountListContainer extends Component {
   }
 
   _getAccountBalance (account) {
-    var meta = MetaCoin.deployed()
-    return new Promise((resolve, reject) => {
-      meta.getBalance.call(account, {from: account}).then(function (value) {
-        resolve({ account: value.valueOf() })
-      }).catch(function (e) {
-        console.log(e)
-        reject()
+    return MetaCoin.deployed()
+      .then(meta => {
+        return meta.getBalance.call(account, {from: account})
       })
-    })
+      .then(function (value) {
+        return { account: value.valueOf() }
+      })
+      .catch(function (e) {
+        console.log(e)
+        throw e
+      })
   }
 
   _getAccountBalances () {

--- a/src/components/SendCoin/SendCoin.js
+++ b/src/components/SendCoin/SendCoin.js
@@ -1,7 +1,10 @@
 import React, { Component } from 'react'
 import './SendCoin.css'
 
-import MetaCoin from 'contracts/MetaCoin.sol';
+import Contract from 'truffle-contract'
+import MetaCoinArtifact from 'contracts/MetaCoin.sol';
+const MetaCoin = Contract(MetaCoinArtifact)
+
 import Web3 from 'web3';
 
 const provider = new Web3.providers.HttpProvider('http://localhost:8545')
@@ -16,13 +19,18 @@ class SendCoin extends Component {
 
   handleSendMeta(e) {
     e.preventDefault()
-    var meta = MetaCoin.deployed();
-    console.log(`Recipient Address: ${this.recipientAddressInput.value}`)
-    meta.sendCoin(this.recipientAddressInput.value, this.sendAmountInput.value, {from: this.props.sender}).then(function() {
-      console.log('SENT')
-    }).catch(function(e) {
-      console.log(e);
-    });
+
+
+    MetaCoin.deployed()
+            .then(meta => {
+              console.log(`Recipient Address: ${this.recipientAddressInput.value}`)
+              return meta.sendCoin(this.recipientAddressInput.value, this.sendAmountInput.value, {from: this.props.sender})
+            })
+            .then(function() {
+              console.log('SENT')
+            }).catch(function(e) {
+              console.log(e);
+            });
   }
 
   render() {

--- a/src/index.js
+++ b/src/index.js
@@ -5,24 +5,21 @@ import Web3 from 'web3'
 
 import './index.css'
 
-import truffleConfig from '../truffle.js'
+var web3Location = `http://${myEnv.host}:${myEnv.port}` //this is defined in webpack DefinePlugin
 
-var web3Location = `http://${truffleConfig.rpc.host}:${truffleConfig.rpc.port}`
-
-window.addEventListener('load', function() {                    
+window.addEventListener('load', function() {
   var web3Provided;
-  // Supports Metamask and Mist, and other wallets that provide 'web3'.      
-  if (typeof web3 !== 'undefined') {                            
-    // Use the Mist/wallet provider.     
-    // eslint-disable-next-line                       
-    web3Provided = new Web3(web3.currentProvider);               
-  } else {                                                      
+  // Supports Metamask and Mist, and other wallets that provide 'web3'.
+  if (typeof web3 !== 'undefined') {
+    // Use the Mist/wallet provider.
+    // eslint-disable-next-line
+    web3Provided = new Web3(web3.currentProvider);
+  } else {
     web3Provided = new Web3(new Web3.providers.HttpProvider(web3Location))
-  }   
-  
+  }
+
   ReactDOM.render(
     <App web3={web3Provided} />,
     document.getElementById('root')
-  )                                                                                                                    
+  )
 });
-

--- a/test/TestMetacoin.sol
+++ b/test/TestMetacoin.sol
@@ -1,0 +1,25 @@
+pragma solidity ^0.4.2;
+
+import "truffle/Assert.sol";
+import "truffle/DeployedAddresses.sol";
+import "../contracts/MetaCoin.sol";
+
+contract TestMetacoin {
+
+  function testInitialBalanceUsingDeployedContract() {
+    MetaCoin meta = MetaCoin(DeployedAddresses.MetaCoin());
+
+    uint expected = 10000;
+
+    Assert.equal(meta.getBalance(tx.origin), expected, "Owner should have 10000 MetaCoin initially");
+  }
+
+  function testInitialBalanceWithNewMetaCoin() {
+    MetaCoin meta = new MetaCoin();
+
+    uint expected = 10000;
+
+    Assert.equal(meta.getBalance(tx.origin), expected, "Owner should have 10000 MetaCoin initially");
+  }
+
+}

--- a/test/metacoin.js
+++ b/test/metacoin.js
@@ -1,29 +1,32 @@
+var MetaCoin = artifacts.require("./MetaCoin.sol");
+
 contract('MetaCoin', function(accounts) {
   it("should put 10000 MetaCoin in the first account", function() {
-    var meta = MetaCoin.deployed();
-
-    return meta.getBalance.call(accounts[0]).then(function(balance) {
+    return MetaCoin.deployed().then(function(instance) {
+      return instance.getBalance.call(accounts[0]);
+    }).then(function(balance) {
       assert.equal(balance.valueOf(), 10000, "10000 wasn't in the first account");
     });
   });
-  it("should call a function that depends on a linked library  ", function(){
-    var meta = MetaCoin.deployed();
+  it("should call a function that depends on a linked library", function() {
+    var meta;
     var metaCoinBalance;
     var metaCoinEthBalance;
 
-    return meta.getBalance.call(accounts[0]).then(function(outCoinBalance){
+    return MetaCoin.deployed().then(function(instance) {
+      meta = instance;
+      return meta.getBalance.call(accounts[0]);
+    }).then(function(outCoinBalance) {
       metaCoinBalance = outCoinBalance.toNumber();
       return meta.getBalanceInEth.call(accounts[0]);
-    }).then(function(outCoinBalanceEth){
+    }).then(function(outCoinBalanceEth) {
       metaCoinEthBalance = outCoinBalanceEth.toNumber();
-
-    }).then(function(){
-      assert.equal(metaCoinEthBalance,2*metaCoinBalance,"Library function returned unexpeced function, linkage may be broken");
-
+    }).then(function() {
+      assert.equal(metaCoinEthBalance, 2 * metaCoinBalance, "Library function returned unexpected function, linkage may be broken");
     });
   });
   it("should send coin correctly", function() {
-    var meta = MetaCoin.deployed();
+    var meta;
 
     // Get initial balances of first and second account.
     var account_one = accounts[0];
@@ -36,7 +39,10 @@ contract('MetaCoin', function(accounts) {
 
     var amount = 10;
 
-    return meta.getBalance.call(account_one).then(function(balance) {
+    return MetaCoin.deployed().then(function(instance) {
+      meta = instance;
+      return meta.getBalance.call(account_one);
+    }).then(function(balance) {
       account_one_starting_balance = balance.toNumber();
       return meta.getBalance.call(account_two);
     }).then(function(balance) {

--- a/truffle.js
+++ b/truffle.js
@@ -1,8 +1,14 @@
 module.exports = {
-  rpc: {
-    host: 'localhost',
-    port: 8545,
-    gas: 190000
-  },
-  migrations_directory: './migrations'
-}
+  networks: {
+    development: {
+      host: "localhost",
+      port: 8545,
+      network_id: "*" // Match any network id
+    },
+    production: {
+      host: "localhost",
+      port: 8546,
+      network_id: "*"
+    }
+  }
+};


### PR DESCRIPTION
Demo will work with Truffle 3.

If you look at the package.json file, i have it linked to my version of `truffle-solidity-loader`. You can run this branch and everything will be ok. But it would be better to have `truffle-solidity-loader` accept the [pull request](https://github.com/ConsenSys/truffle-solidity-loader/pull/10) to make it work with Truffle 3. A later commit can be issued to remove my direct repo link to a version number.

@tcoulter @johnmcdowall